### PR TITLE
atheepmgr: bugfix missing libpciaccess dependency

### DIFF
--- a/utils/atheepmgr/Makefile
+++ b/utils/atheepmgr/Makefile
@@ -25,6 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/atheepmgr
   SECTION:=utils
   CATEGORY:=Utilities
+  DEPENDS:=+libpciaccess
   TITLE:=EEPROM/boarddata management utility for Atheros WLAN chips
   MENU:=1
 endef


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
